### PR TITLE
Use the correct variable for the carbon_log_dir

### DIFF
--- a/templates/opt/graphite/bin/carbon-logrotate.sh.erb
+++ b/templates/opt/graphite/bin/carbon-logrotate.sh.erb
@@ -3,7 +3,7 @@
 # Because graphite has now way to configure the logrotation,
 # we do that with a cronjob and this script.
  
-CARBON_LOGS_PATH="<%= scope.lookupvar('graphite::graphiteweb_log_dir_REAL') %>"
+CARBON_LOGS_PATH="<%= scope.lookupvar('graphite::carbon_log_dir_REAL') %>"
 CARBON_LOGS="carbon-cache/ carbon-relay/ carbon-aggregator/"
 
 ROTATE_DAYS=3


### PR DESCRIPTION
It shouldn't follow the location of the graphite-web logs, but the location of the carbon logs.